### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,30 +126,35 @@
 |  
 | https://github.com/rust-lang-ru/dictionary/issues/26[#26] 
 
+| dangling pointer / dangling reference
+| висячий указатель / висячая ссылка
+|
+|
+
 | debuging
 | отладка, отлаживать
 | 
 | 
-
-| destructure/destructuring
-| деструктуризация
-| 
-| https://github.com/rust-lang-ru/dictionary/issues/13[#13] 
 
 | dereferencing
 | разыменование
 | 
 | https://github.com/rust-lang-ru/dictionary/issues/10[#10] 
 
-| dot operator
-| оператор точка
-| https://doc.rust-lang.org/reference/introduction.html?search=dot["." в reference]
-| https://github.com/rust-lang-ru/dictionary/issues/14[#14] 
-
 | derive
 | генерировать
 | автоматическая реализации поведения для типа (`+#[derive(Debug)]+`) 
 | https://github.com/rust-lang-ru/dictionary/issues/20[#20] 
+
+| destructure/destructuring
+| деструктуризация
+| 
+| https://github.com/rust-lang-ru/dictionary/issues/13[#13] 
+
+| dot operator
+| оператор точка
+| https://doc.rust-lang.org/reference/introduction.html?search=dot["." в reference]
+| https://github.com/rust-lang-ru/dictionary/issues/14[#14] 
 
 | edition
 | редакция

--- a/README.adoc
+++ b/README.adoc
@@ -127,7 +127,7 @@
 | https://github.com/rust-lang-ru/dictionary/issues/26[#26] 
 
 | dangling pointer / dangling reference
-| висячий указатель / висячая ссылка
+| висящий указатель / висящая ссылка
 |
 |
 


### PR DESCRIPTION
Закрепляет используемую в книгу версию dangling. 
Меняет местами пару определения, так как они не по алфавиту.